### PR TITLE
fix: handle non-existent window gracefully

### DIFF
--- a/src/egui.wgsl
+++ b/src/egui.wgsl
@@ -1,23 +1,23 @@
 struct Transform {
-    scale: vec2<f32>;
-    translation: vec2<f32>;
-};
+    scale: vec2<f32>,
+    translation: vec2<f32>,
+}
 
 struct VertexInput {
-    [[location(0)]] position: vec2<f32>;
-    [[location(1)]] uv: vec2<f32>;
-    [[location(2)]] color: vec4<f32>;
-};
+    @location(0) position: vec2<f32>,
+    @location(1) uv: vec2<f32>,
+    @location(2) color: vec4<f32>,
+}
 
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] color: vec4<f32>;
-    [[location(1)]] uv: vec2<f32>;
-};
+    @builtin(position) position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+    @location(1) uv: vec2<f32>,
+}
 
-[[group(0), binding(0)]] var<uniform> transform: Transform;
-[[group(1), binding(0)]] var image_texture: texture_2d<f32>;
-[[group(1), binding(1)]] var image_sampler: sampler;
+@group(0) @binding(0) var<uniform> transform: Transform;
+@group(1) @binding(0) var image_texture: texture_2d<f32>;
+@group(1) @binding(1) var image_sampler: sampler;
 
 fn linear_from_srgb(srgb: vec3<f32>) -> vec3<f32> {
     let cutoff = srgb < vec3<f32>(0.04045);
@@ -26,15 +26,15 @@ fn linear_from_srgb(srgb: vec3<f32>) -> vec3<f32> {
     return select(higher, lower, cutoff);
 }
 
-[[stage(vertex)]]
+@vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
     let position = in.position * transform.scale + transform.translation;
     let color = vec4<f32>(linear_from_srgb(in.color.rgb), in.color.a);
     return VertexOutput(vec4<f32>(position, 0.0, 1.0), color, in.uv);
 }
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let texture_color = textureSample(image_texture, image_sampler, in.uv);
     // This assumes that texture images are not premultiplied.
     let color = in.color * vec4<f32>(texture_color.rgb * texture_color.a, texture_color.a);

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -322,8 +322,15 @@ impl Node for EguiNode {
 
         let egui_transforms = world.get_resource::<EguiTransforms>().unwrap();
 
-        let extracted_window =
-            &world.get_resource::<ExtractedWindows>().unwrap().windows[&self.window_id];
+        let extracted_window = match world
+            .get_resource::<ExtractedWindows>()
+            .unwrap()
+            .windows
+            .get(&self.window_id)
+        {
+            Some(id) => id,
+            None => return Ok(()),
+        };
         let swap_chain_texture = extracted_window.swap_chain_texture.as_ref().unwrap();
 
         let mut render_pass =

--- a/src/egui_node.rs
+++ b/src/egui_node.rs
@@ -4,12 +4,12 @@ use bevy::{
     render::{
         render_graph::{Node, NodeRunError, RenderGraphContext},
         render_resource::{
-            BindGroupLayout, BindGroupLayoutDescriptor, BindGroupLayoutEntry,
+            encase::ShaderType, BindGroupLayout, BindGroupLayoutDescriptor, BindGroupLayoutEntry,
             BindingType, BlendComponent, BlendFactor, BlendOperation, BlendState, Buffer,
-            BufferAddress, BufferBindingType, BufferDescriptor, encase::ShaderType, BufferUsages,
-            ColorTargetState, ColorWrites, Extent3d, FrontFace, IndexFormat, LoadOp,
-            MultisampleState, Operations, PipelineLayoutDescriptor, PrimitiveState,
-            RawFragmentState, RawRenderPipelineDescriptor, RawVertexBufferLayout, RawVertexState,
+            BufferAddress, BufferBindingType, BufferDescriptor, BufferUsages, ColorTargetState,
+            ColorWrites, Extent3d, FrontFace, IndexFormat, LoadOp, MultisampleState, Operations,
+            PipelineLayoutDescriptor, PrimitiveState, RawFragmentState,
+            RawRenderPipelineDescriptor, RawVertexBufferLayout, RawVertexState,
             RenderPassColorAttachment, RenderPassDescriptor, RenderPipeline, SamplerBindingType,
             ShaderModuleDescriptor, ShaderSource, ShaderStages, TextureDimension, TextureFormat,
             TextureSampleType, TextureViewDimension, VertexAttribute, VertexFormat, VertexStepMode,
@@ -38,7 +38,7 @@ impl FromWorld for EguiPipeline {
         let render_device = world.get_resource::<RenderDevice>().unwrap();
 
         let shader_source = ShaderSource::Wgsl(include_str!("egui.wgsl").into());
-        let shader_module = render_device.create_shader_module(&ShaderModuleDescriptor {
+        let shader_module = render_device.create_shader_module(ShaderModuleDescriptor {
             label: Some("egui shader"),
             source: shader_source,
         });
@@ -117,7 +117,7 @@ impl FromWorld for EguiPipeline {
             fragment: Some(RawFragmentState {
                 module: &shader_module,
                 entry_point: "fs_main",
-                targets: &[ColorTargetState {
+                targets: &[Some(ColorTargetState {
                     format: TextureFormat::bevy_default(),
                     blend: Some(BlendState {
                         color: BlendComponent {
@@ -132,7 +132,7 @@ impl FromWorld for EguiPipeline {
                         },
                     }),
                     write_mask: ColorWrites::ALL,
-                }],
+                })],
             }),
             primitive: PrimitiveState {
                 front_face: FrontFace::Cw,
@@ -338,14 +338,14 @@ impl Node for EguiNode {
                 .command_encoder
                 .begin_render_pass(&RenderPassDescriptor {
                     label: Some("egui render pass"),
-                    color_attachments: &[RenderPassColorAttachment {
+                    color_attachments: &[Some(RenderPassColorAttachment {
                         view: swap_chain_texture,
                         resolve_target: None,
                         ops: Operations {
                             load: LoadOp::Load,
                             store: true,
                         },
-                    }],
+                    })],
                     depth_stencil_attachment: None,
                 });
 

--- a/src/render_systems.rs
+++ b/src/render_systems.rs
@@ -8,11 +8,12 @@ use bevy::{
     render::{
         render_asset::RenderAssets,
         render_resource::{
-            BindGroup, BindGroupDescriptor, BindGroupEntry, BindingResource,
-            BufferId, DynamicUniformBuffer, encase::{ShaderType},
+            encase::ShaderType, BindGroup, BindGroupDescriptor, BindGroupEntry, BindingResource,
+            BufferId, DynamicUniformBuffer,
         },
         renderer::{RenderDevice, RenderQueue},
         texture::Image,
+        Extract,
     },
     utils::HashMap,
     window::WindowId,
@@ -53,12 +54,12 @@ impl ExtractedEguiTextures {
 
 pub(crate) fn extract_egui_render_data(
     mut commands: Commands,
-    mut egui_render_output: ResMut<HashMap<WindowId, EguiRenderOutput>>,
-    window_sizes: ResMut<HashMap<WindowId, WindowSize>>,
-    egui_settings: Res<EguiSettings>,
-    egui_context: Res<EguiContext>,
+    egui_render_output: Extract<Res<HashMap<WindowId, EguiRenderOutput>>>,
+    window_sizes: Extract<Res<HashMap<WindowId, WindowSize>>>,
+    egui_settings: Extract<Res<EguiSettings>>,
+    egui_context: Extract<Res<EguiContext>>,
 ) {
-    let render_output = std::mem::take(&mut *egui_render_output);
+    let render_output = egui_render_output.clone();
     commands.insert_resource(ExtractedRenderOutput(render_output));
     commands.insert_resource(ExtractedEguiSettings(egui_settings.clone()));
     commands.insert_resource(ExtractedEguiContext(egui_context.ctx.clone()));
@@ -67,8 +68,8 @@ pub(crate) fn extract_egui_render_data(
 
 pub(crate) fn extract_egui_textures(
     mut commands: Commands,
-    egui_context: Res<EguiContext>,
-    egui_managed_textures: ResMut<EguiManagedTextures>,
+    egui_context: Extract<Res<EguiContext>>,
+    egui_managed_textures: Extract<Res<EguiManagedTextures>>,
 ) {
     commands.insert_resource(ExtractedEguiTextures {
         egui_textures: egui_managed_textures


### PR DESCRIPTION
Hi there!

I'm using your branch with Bevy 0.8 and noticed it was crashing on exit for me. Looks like it's because the window it tries to retrieve from `ExtractedWindows` isn't available when shutting down any more.

Not sure if this is "the" fix, but it works for me, so 🤷 